### PR TITLE
Adjust Apple Music player iframe size and enable autoplay

### DIFF
--- a/src/components/floating-apple-music-player.tsx
+++ b/src/components/floating-apple-music-player.tsx
@@ -108,8 +108,8 @@ export default function FloatingAppleMusicPlayer() {
                 title="Vibe Coding Paris – Apple Music"
                 allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"
                 sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation"
-                src="https://embed.music.apple.com/fr/playlist/vibe-coding-paris/pl.u-b3b8aYNIylP0pZ"
-                className="w-full h-[400px] md:w-[380px] border-0"
+                src="https://embed.music.apple.com/fr/playlist/vibe-coding-paris/pl.u-b3b8aYNIylP0pZ?autoplay=1"
+                className="w-full h-[175px] md:w-[350px] border-0"
                 style={{ background: 'transparent' }}
               />
             </div>


### PR DESCRIPTION
## Summary
- Updated the Apple Music playlist iframe in the floating player component
- Enabled autoplay for the embedded playlist
- Adjusted iframe height and width for better UI fit

## Changes

### UI Component Updates
- Modified `FloatingAppleMusicPlayer` component:
  - Added `?autoplay=1` query parameter to the Apple Music playlist URL to enable autoplay
  - Reduced iframe height from 400px to 175px and width from 380px to 350px on medium screens

## Test plan
- [x] Verify the Apple Music playlist starts playing automatically on component load
- [x] Confirm the iframe size changes reflect correctly on different screen sizes
- [x] Ensure no regressions in player functionality or UI layout

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1c5819ef-83b2-4458-946f-5f6cd304a7d8