### PR TITLE
fix(landing): update business line break and wording in hero component

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -9,7 +9,7 @@ export default function Hero() {
           Pendant qu'ils scrollent, <br /> toi t'apprends à Vibe coder.
         </h1>
         <p className="mt-4 max-w-2xl mx-auto text-lg text-muted-foreground md:text-xl">
-          2h. Business, rien de perso. Juste toi et ton projet en ligne.
+          2h. Business, rien de personnel. <br /> Juste toi et ton projet en ligne.
         </p>
         <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
           <Button size="lg" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground relative">


### PR DESCRIPTION
## Summary
- Refines the business line text in the landing page hero component
- Adds a line break for better readability
- Changes "perso" to "personnel" for clarity

## Changes

### UI Components
- **Hero Component**: Updated the paragraph text to:
  - Replace "2h. Business, rien de perso. Juste toi et ton projet en ligne." with
    "2h. Business, rien de personnel. <br /> Juste toi et ton projet en ligne."
  - Added a `<br />` tag to break the line for improved visual structure

## Test plan
- [x] Verify the updated text appears correctly on the landing page
- [x] Confirm the line break renders properly on different screen sizes
- [x] Ensure no layout regressions in the hero section

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9c25af34-5fb7-48f1-92dc-6851449a1d46