### PR TITLE
Refine hero subtitle text on landing page

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -9,7 +9,7 @@ export default function Hero() {
           Pendant qu'ils scrollent, <br /> toi t'apprends à Vibe coder.
         </h1>
         <p className="mt-4 max-w-2xl mx-auto text-lg text-muted-foreground md:text-xl">
-          2h. Business, rien de personnel. <br /> Juste toi et ton projet en ligne.
+          2h. Business, rien de personnel.
         </p>
         <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
           <Button size="lg" asChild className="bg-accent hover:bg-accent/90 text-accent-foreground relative">


### PR DESCRIPTION
## Summary
- Updated the subtitle text in the Hero component on the landing page
- Removed the line break and shortened the subtitle for a cleaner presentation

## Changes

### UI Components
- **Hero Component**: Modified the paragraph text to remove the `<br />` tag and simplify the message from:
  ```
  2h. Business, rien de personnel. <br /> Juste toi et ton projet en ligne.
  ```
  to:
  ```
  2h. Business, rien de personnel.
  ```

## Test plan
- [x] Verified the subtitle text displays correctly without the line break
- [x] Checked responsiveness and visual alignment on different screen sizes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9c25af34-5fb7-48f1-92dc-6851449a1d46