### PR TITLE
Fix dark mode school logos by using resolvedTheme

### DIFF
--- a/src/components/landing/partners.tsx
+++ b/src/components/landing/partners.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
 export default function Partners() {
-  const { theme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -31,11 +31,11 @@ export default function Partners() {
     );
   }
 
-  // Déterminer quelle image utiliser selon le thème
-  const logoSrc =
-    theme === "dark"
-      ? "/Schools/schools-logos_white.png"
-      : "/Schools/schools-logos_black.png";
+  // Utiliser resolvedTheme qui donne le thème réel (même si theme est "system")
+  const isDark = resolvedTheme === "dark";
+  const logoSrc = isDark
+    ? "/Schools/schools-logos_white.png"
+    : "/Schools/schools-logos_black.png";
 
   return (
     <section className="bg-background">


### PR DESCRIPTION
## Summary
- Fixes the issue with school logos not displaying correctly in dark mode
- Uses `resolvedTheme` from `next-themes` to get the actual theme instead of `theme` which can be "system"

## Changes

### Components
- **Partners Component**: Updated to use `resolvedTheme` instead of `theme` to determine if the dark mode is active
- Adjusted logo source selection logic to use `resolvedTheme` for accurate theme detection

## Test plan
- [x] Verify that the correct school logos are displayed in dark mode
- [x] Verify that the correct school logos are displayed in light mode
- [x] Test theme switching between light, dark, and system modes to ensure logos update accordingly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0ec7dc27-e103-4e4b-893f-d2753ae0776e