### PR TITLE
Update BYOD section with improved benefits and layout

### DIFF
--- a/src/components/landing/byod.tsx
+++ b/src/components/landing/byod.tsx
@@ -27,12 +27,12 @@ const requirements = [
 
 const benefits = [
   {
-    icon: <Settings className="h-8 w-8 text-primary" />,
-    title: "Configuration simple",
-    description: "Matériel requis minimal"
+    icon: <Laptop className="h-8 w-8 text-primary" />,
+    title: "Apportez votre laptop",
+    description: "PC, Mac voire un Smartphone (limité)"
   },
   {
-    icon: <Laptop className="h-8 w-8 text-primary" />,
+    icon: <Settings className="h-8 w-8 text-primary" />,
     title: "Accessible",
     description: "Aucune expérience de code requise"
   },
@@ -69,7 +69,7 @@ export default function BYOD() {
             <h3 className="text-2xl font-bold text-foreground mb-8 font-headline">
               Liste de vérification
             </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-3xl mx-auto">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
               {requirements.map((requirement, index) => (
                 <div key={index} className="flex items-center gap-3 p-4 rounded-lg bg-muted/30 transition-all hover:bg-muted/50">
                   {requirement.icon}


### PR DESCRIPTION
## Summary
- Updated the "Bring Your Own Device" (BYOD) section on the landing page
- Swapped icons and updated titles and descriptions for better clarity
- Increased the max width of the checklist grid for improved layout

## Changes

### UI Components
- **BYOD Benefits**: 
  - Changed the first benefit icon from `Settings` to `Laptop`
  - Updated the first benefit title to "Apportez votre laptop"
  - Updated the first benefit description to "PC, Mac voire un Smartphone (limité)"
  - Swapped the second benefit icon from `Laptop` to `Settings`
- **Checklist Layout**:
  - Increased the max width of the checklist grid container from `max-w-3xl` to `max-w-4xl` for better spacing

## Test plan
- [x] Verify the BYOD benefits section displays the correct icons, titles, and descriptions
- [x] Confirm the checklist grid layout adapts correctly with the increased max width
- [x] Check for any visual regressions on different screen sizes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9a29dd52-976e-4d6d-82e5-d351c73ad204