### PR TITLE
Add line breaks for improved readability in landing page headings

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
         <section id="ateliers" className="py-12 md:py-20 lg:py-24">
           <div className="text-center mb-8 md:mb-12">
             <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl md:text-4xl lg:text-5xl font-headline">
-              Nos Ateliers en Solutions Gen AI
+              Nos Ateliers<br />en Solutions Gen AI
             </h2>
             <p className="text-muted-foreground mt-1 md:mt-2 text-sm md:text-base">
               pendant l'année académique 2024 - 2025

--- a/src/components/landing/partners.tsx
+++ b/src/components/landing/partners.tsx
@@ -19,7 +19,7 @@ export default function Partners() {
         <div className="container mx-auto px-4">
           <div className="text-center mb-8">
             <h3 className="text-lg font-semibold text-muted-foreground font-headline">
-              Un grand merci à tous mes Étudiants en Bachelor, Master & MBA en
+              Un grand merci à tous mes Étudiants en Bachelor, Master & MBA<br />en
               2024-2025 👏
             </h3>
           </div>
@@ -42,7 +42,7 @@ export default function Partners() {
       <div className="container mx-auto px-4">
         <div className="text-center mb-8">
           <h3 className="text-lg font-semibold text-muted-foreground font-headline">
-            Un grand merci à tous mes Étudiants en Bachelor, Master & MBA en
+            Un grand merci à tous mes Étudiants en Bachelor, Master & MBA<br />en
             2024-2025 👏
           </h3>
         </div>


### PR DESCRIPTION
## Summary
- Introduces line breaks in key headings on the landing page for better visual structure
- Enhances text presentation in the "Nos Ateliers en Solutions Gen AI" section
- Improves the "Un grand merci à tous mes Étudiants en Bachelor, Master & MBA en 2024-2025" acknowledgments

## Changes

### UI Text Updates
- Added `<br />` tags in the main heading of the ateliers section to split the text into two lines
- Inserted `<br />` tags in the partners component headings to break long lines for better readability

## Test plan
- [x] Verify that the ateliers section heading displays with a line break
- [x] Confirm the partners section acknowledgments show line breaks as intended
- [x] Check that the layout remains responsive and visually balanced on different screen sizes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fab8d406-23a3-46f3-adf2-93420e719d4d