### PR TITLE
Fix line break issue in desktop skill headline

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -17,7 +17,7 @@ export default function Hero() {
         </div>
         
         <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-headline">
-          Une compétence<br />en 2h.<br />Rien de personnel.
+          Une compétence<span className="block md:inline"> </span>en 2h.<br />Rien de personnel.
         </h1>
         <p className="mt-2 md:mt-4 max-w-2xl mx-auto text-base text-muted-foreground md:text-lg lg:text-xl">
           Apprends à coder sans coder.<br />Tu écris en français, l'IA génère le code, tu déploies ton site.


### PR DESCRIPTION
## Summary
- Adjusts the line break in the skill headline on the landing page for better desktop display
- Replaces a hard `<br />` line break with a conditional inline block to improve text flow on medium and larger screens

## Changes

### UI Components
- **Hero Component**: Modified the headline text in `src/components/landing/hero.tsx`:
  - Changed `Une compétence<br />en 2h.` to `Une compétence<span className="block md:inline"> </span>en 2h.`
  - This change ensures the space behaves as a block element on small screens and inline on medium and larger screens, preventing awkward line breaks

## Test plan
- [x] Verify the headline displays correctly on mobile, tablet, and desktop screen sizes
- [x] Confirm that the line break appears only on smaller screens and the text flows inline on larger screens
- [x] Check for any visual regressions in the landing page hero section

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2a0aad70-3229-4f2c-813d-96e29db0fdf5