### PR TITLE
Limit changelog PR display to 5, update description text, and adjust hero heading for responsiveness

### DIFF
--- a/src/components/landing/changelog.tsx
+++ b/src/components/landing/changelog.tsx
@@ -61,7 +61,7 @@ async function fetchPullRequests(): Promise<GitHubPullRequest[]> {
         const dateB = new Date(b.merged_at || b.closed_at).getTime();
         return dateB - dateA;
       })
-      .slice(0, 8);
+      .slice(0, 5);
 
     return filteredPRs;
   } catch (err) {
@@ -95,7 +95,7 @@ export default async function Changelog() {
             Changelog
           </h2>
           <p className="text-muted-foreground mt-1 md:mt-2 text-sm md:text-base">
-            Dernières contributions et améliorations
+            Ce site évolue en continu avec la compétence que vous allez acquérir
           </p>
         </div>
 

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -17,7 +17,17 @@ export default function Hero() {
         </div>
         
         <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-headline">
-          Une compétence<br />en 2h.<br />Rien de personnel.
+          {/* Version mobile: Une compétence → 2h. → Rien de personnel. */}
+          <span className="block md:hidden">
+            Une compétence<br />
+            2h.<br />
+            Rien de personnel.
+          </span>
+          {/* Version desktop: Une compétence en 2h. → Rien de personnel. */}
+          <span className="hidden md:block">
+            Une compétence en 2h.<br />
+            Rien de personnel.
+          </span>
         </h1>
         <p className="mt-2 md:mt-4 max-w-2xl mx-auto text-base text-muted-foreground md:text-lg lg:text-xl">
           Apprends à coder sans coder.<br />Tu écris en français, l'IA génère le code, tu déploies ton site.


### PR DESCRIPTION
## Summary
- Reduced the number of pull requests displayed in the changelog from 8 to 5
- Updated the changelog description text to better reflect ongoing site improvements
- Adjusted the hero component heading to display differently on mobile and desktop for improved readability

## Changes

### Changelog Component
- Modified the slice method in `fetchPullRequests` to limit displayed PRs to 5 instead of 8
- Changed the description paragraph text from "Dernières contributions et améliorations" to "Ce site évolue en continu avec la compétence que vous allez acquérir" to emphasize continuous evolution and user skill acquisition

### Hero Component
- Updated the main heading to show a multi-line version on mobile and a slightly different line break on desktop for better visual presentation

## Test plan
- [x] Verify that only 5 pull requests are shown in the changelog
- [x] Confirm the updated description text appears correctly on the landing page
- [x] Ensure the hero heading displays correctly on both mobile and desktop views
- [x] Ensure no layout or styling regressions occur due to text and heading changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f5a784b5-ff6c-4518-ac54-2734e1ed6fbf