### PR TITLE
Update pricing plan UI and link anchors in landing page

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -75,13 +75,13 @@ export default function Pricing() {
                         </CardContent>
                         <CardFooter className="flex-col gap-3">
                             <Button className="w-full bg-accent hover:bg-accent/90" asChild>
-                                <Link href="https://buy.stripe.com/bJe8wQ3dN7NGc5EcJv7EQ0b">Je m'inscris — 149 €</Link>
+                                <Link href="#checkout-149">Je m'inscris — 149 €</Link>
                             </Button>
                         </CardFooter>
                     </Card>
 
-                    {/* Standard Card */}
-                    <Card className="flex flex-col h-full w-full max-w-sm transition-all hover:scale-[1.02] hover:shadow-lg">
+                    {/* Standard Card - Highlighted */}
+                    <Card className="flex flex-col h-full w-full max-w-sm border-2 border-primary shadow-2xl shadow-primary/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
                         <CardHeader className="pb-4">
                             <CardTitle className="font-headline text-xl">🚀 Devenez Product Builder</CardTitle>
                             <div className="flex items-baseline gap-2">
@@ -101,7 +101,7 @@ export default function Pricing() {
                         </CardContent>
                         <CardFooter>
                             <Button className="w-full" asChild>
-                                <Link href="https://buy.stripe.com/bJe5kEdSrgkcfhQaBn7EQ0c">Réserver — 299 €</Link>
+                                <Link href="#checkout-299">Réserver — 299 €</Link>
                             </Button>
                         </CardFooter>
                     </Card>
@@ -127,7 +127,7 @@ export default function Pricing() {
                         </CardContent>
                         <CardFooter>
                             <Button className="w-full" variant="outline" asChild>
-                                <Link href="https://cal.com/tewfiqferahi/15min" target="_blank" rel="noopener noreferrer">Demander un devis</Link>
+                                <Link href="#contact">Demander un devis</Link>
                             </Button>
                         </CardFooter>
                     </Card>


### PR DESCRIPTION
## Summary
- Updated pricing plan cards on the landing page for better visual emphasis and user navigation
- Changed external Stripe purchase links to internal anchor links for smoother in-page navigation
- Highlighted the "Standard Card" with border and shadow to draw user attention

## Changes

### UI Enhancements
- Added border and shadow to the "Standard Card" to make it visually prominent
- Adjusted hover effects for pricing cards to improve interactivity feedback

### Link Updates
- Replaced external Stripe purchase URLs with internal anchor links (`#checkout-149`, `#checkout-299`) for the pricing buttons
- Changed the "Demander un devis" button link from an external scheduling URL to an internal anchor `#contact`

## Test plan
- [x] Verify that pricing cards render with updated styles and hover effects
- [x] Confirm that clicking pricing buttons scrolls to the respective checkout sections
- [x] Ensure the "Demander un devis" button scrolls to the contact section
- [x] Check that no external links are broken or incorrectly referenced

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/cc3a613e-b3eb-4e6a-ac59-18d8bd1f72a9