### PR TITLE
Rename 'Réduit' pricing plan to 'Starter' and update features list

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -13,7 +13,7 @@ const includedFeaturesStarter = [
 
 const includedFeatures = [
     'Atelier 2h intensif en présentiel',
-    'Méthode complète end-to-end : idée → code → déploiement',
+    'Méthode complète end-to-end :<br />idée → code → déploiement',
     'Pratique guidée étape par étape',
     'Projet en ligne, immédiatement partageable',
     'Kit documentaire pour continuer après l\'atelier',

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -4,7 +4,7 @@ import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/componen
 import { Check } from 'lucide-react';
 import SocialProofBadge from '@/components/landing/social-proof-badge';
 
-const includedFeaturesReduit = [
+const includedFeaturesStarter = [
     'Atelier 2h complet',
     'Même contenu que l\'atelier principal',
     'Coaching & accompagnement',
@@ -50,10 +50,10 @@ export default function Pricing() {
                 </div>
                 
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 max-w-6xl mx-auto items-start justify-items-center">
-                    {/* Réduit Card - Featured */}
+                    {/* Starter Card - Featured */}
                     <Card className="flex flex-col h-full w-full max-w-sm border-2 border-accent shadow-2xl shadow-accent/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
                         <CardHeader className="pb-4">
-                            <CardTitle className="font-headline text-2xl">Réduit</CardTitle>
+                            <CardTitle className="font-headline text-2xl">Starter</CardTitle>
                             <div className="flex items-baseline gap-2">
                                 <span className="text-5xl font-bold tracking-tight text-accent">149 €</span>
                             </div>
@@ -61,7 +61,7 @@ export default function Pricing() {
                         </CardHeader>
                         <CardContent className="flex-1">
                             <ul className="space-y-3 text-sm">
-                                {includedFeaturesReduit.map(feature => (
+                                {includedFeaturesStarter.map(feature => (
                                     <li key={feature} className="flex items-center gap-2">
                                         <Check className="h-4 w-4 text-accent" />
                                         <span className="text-muted-foreground">{feature}</span>


### PR DESCRIPTION
## Summary
- Renamed the pricing plan from "Réduit" to "Starter" in the landing pricing component
- Updated the associated features list variable name from `includedFeaturesReduit` to `includedFeaturesStarter`
- Adjusted all references in the pricing card to reflect the new plan name and features list

## Changes

### Pricing Component Updates
- Renamed `includedFeaturesReduit` array to `includedFeaturesStarter` to better represent the plan
- Changed the card title from "Réduit" to "Starter" in the pricing display
- Updated the features list rendering to use the new `includedFeaturesStarter` array

## Test plan
- [x] Verify the pricing card displays "Starter" as the plan name
- [x] Confirm the features listed match the updated `includedFeaturesStarter` array
- [x] Check that the styling and layout remain consistent after the rename
- [x] Ensure no references to "Réduit" remain in the pricing component

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/cc3a613e-b3eb-4e6a-ac59-18d8bd1f72a9