### PR TITLE
Add emojis to pricing card titles for visual enhancement

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -53,7 +53,7 @@ export default function Pricing() {
                     {/* Starter Card - Featured */}
                     <Card className="flex flex-col h-full w-full max-w-sm border-2 border-accent shadow-2xl shadow-accent/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
                         <CardHeader className="pb-4">
-                            <CardTitle className="font-headline text-2xl">Starter</CardTitle>
+                            <CardTitle className="font-headline text-2xl">⭐ Starter</CardTitle>
                             <div className="flex items-baseline gap-2">
                                 <span className="text-5xl font-bold tracking-tight text-accent">149 €</span>
                             </div>
@@ -105,7 +105,7 @@ export default function Pricing() {
                     {/* Team Card */}
                     <Card className="flex flex-col h-full w-full max-w-sm transition-all hover:scale-[1.02] hover:shadow-lg">
                         <CardHeader className="pb-4">
-                            <CardTitle className="font-headline text-2xl">Équipe</CardTitle>
+                            <CardTitle className="font-headline text-2xl">👥 Équipe</CardTitle>
                             <div className="flex items-baseline gap-2">
                                 <span className="text-5xl font-bold tracking-tight">Sur devis</span>
                             </div>


### PR DESCRIPTION
## Summary
- Adds emojis to the titles of pricing cards on the landing page
- Enhances visual appeal and helps differentiate pricing tiers

## Changes

### UI Components
- Updated `Starter` card title to include a star emoji (⭐)
- Updated `Équipe` card title to include a team emoji (👥)

## Test plan
- [x] Verify that the Starter card title displays the star emoji correctly
- [x] Verify that the Équipe card title displays the team emoji correctly
- [x] Ensure no layout or styling issues occur due to emoji addition

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4b77e4b0-8827-4302-94d3-0358eb3e56ff