### PR TITLE
Fix grammar in mobile hero text

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -20,7 +20,7 @@ export default function Hero() {
           {/* Version mobile: Une compétence → 2h. → Rien de personnel. */}
           <span className="block md:hidden">
             Une compétence<br />
-            2h.<br />
+            en 2h.<br />
             Rien de personnel.
           </span>
           {/* Version desktop: Une compétence en 2h. → Rien de personnel. */}


### PR DESCRIPTION
## Summary
- Corrects the phrasing in the mobile version of the hero component text

## Changes

### UI Components
- **Hero Component**: Updated mobile text from "2h." to "en 2h." for better readability and grammatical correctness

## Test plan
- [x] Verify the mobile hero text displays as "Une compétence\nen 2h.\nRien de personnel." on small screens
- [x] Confirm desktop version remains unchanged

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/67a37e26-c818-4775-a21e-699f13bf8868