### PR TITLE
Fix mobile tabs layout and description width in Feature108 component

### DIFF
--- a/src/components/ui/shadcnblocks-com-feature108.tsx
+++ b/src/components/ui/shadcnblocks-com-feature108.tsx
@@ -40,18 +40,18 @@ const Feature108 = ({
         <div className="flex flex-col items-center gap-4 text-center">
           <Badge variant="outline">{badge}</Badge>
           <h1 className="max-w-3xl text-3xl font-semibold md:text-4xl">{heading}</h1>
-          <p className="text-muted-foreground">{description}</p>
+          <p className="text-muted-foreground max-w-2xl">{description}</p>
         </div>
 
         <Tabs defaultValue={tabs[0]?.value} className="mt-8">
           {/* Mobile: Horizontal scroll, Desktop: Centered row */}
           <div className="container">
-            <TabsList className="flex w-full overflow-x-auto scrollbar-hide gap-2 sm:justify-center sm:gap-4 md:gap-10 pb-2 sm:pb-0">
+            <TabsList className="flex w-full overflow-x-auto scrollbar-hide gap-3 md:justify-center md:gap-6 lg:gap-10 pb-2 md:pb-0 h-auto">
               {tabs.map((tab) => (
                 <TabsTrigger
                   key={tab.value}
                   value={tab.value}
-                  className="flex items-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold text-muted-foreground data-[state=active]:bg-muted data-[state=active]:text-primary whitespace-nowrap flex-shrink-0"
+                  className="flex items-center gap-2 rounded-xl px-3 py-2 sm:px-4 sm:py-3 text-xs sm:text-sm font-semibold text-muted-foreground data-[state=active]:bg-muted data-[state=active]:text-primary whitespace-nowrap flex-shrink-0 min-w-fit"
                 >
                   {tab.icon} {tab.label}
                 </TabsTrigger>


### PR DESCRIPTION
## Summary
- Adjusts the mobile tabs layout for better spacing and alignment
- Limits the description text width for improved readability
- Updates padding and font sizes for tab triggers to enhance mobile usability

## Changes

### UI Component: Feature108
- Added `max-w-2xl` class to the description paragraph to constrain its width
- Modified `TabsList` classes to increase gap spacing and adjust justification on different screen sizes
- Updated `TabsTrigger` classes to reduce padding on smaller screens, add minimum width, and adjust font sizes for better mobile display

## Test plan
- [x] Verify description text does not stretch too wide on mobile and desktop
- [x] Check horizontal scrolling behavior of tabs on mobile devices
- [x] Confirm tab triggers have consistent padding and font size across breakpoints
- [x] Ensure active tab styling remains intact after changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/134cd05d-9556-4ef3-beed-650c628d6e49