### PR TITLE
Fix changelog card summary layout and text wrapping

### DIFF
--- a/src/components/landing/changelog.tsx
+++ b/src/components/landing/changelog.tsx
@@ -167,10 +167,10 @@ export default async function Changelog() {
                     <div className="flex items-start justify-between">
                       <div className="space-y-2 flex-1">
                         <div className="flex flex-col sm:flex-row sm:items-start gap-3">
-                          <div className="flex items-center gap-2 flex-1 min-w-0">
-                            <CardTitle className="text-lg flex items-center gap-2 truncate">
-                              <GitPullRequest className="h-4 w-4 flex-shrink-0" />
-                              <span className="truncate">PR #{pr.number}: {pr.title}</span>
+                          <div className="flex items-start gap-2 flex-1 min-w-0">
+                            <GitPullRequest className="h-4 w-4 flex-shrink-0 mt-1" />
+                            <CardTitle className="text-lg break-words leading-tight">
+                              PR #{pr.number}: {pr.title}
                             </CardTitle>
                           </div>
                           <div className="flex items-center gap-2 flex-shrink-0">


### PR DESCRIPTION
## Summary
- Adjusts the layout and styling of the changelog card summary in the landing page component
- Fixes text truncation issues by enabling word wrapping and improving alignment

## Changes

### UI Component Updates
- Modified the changelog card summary container to use `flex-start` alignment instead of `center` for better vertical alignment
- Added `mt-1` margin to the GitPullRequest icon for proper spacing
- Changed the `CardTitle` styling to use `break-words` and `leading-tight` for improved text wrapping and readability

## Test plan
- [x] Verify that PR titles in the changelog card no longer truncate prematurely
- [x] Confirm the GitPullRequest icon aligns properly with the text
- [x] Check the layout on different screen sizes to ensure responsiveness and readability

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/38cdc89f-daae-450a-94f8-6b0fb838098e