### PR TITLE
Fix container max width in program section of Feature108

### DIFF
--- a/src/components/ui/shadcnblocks-com-feature108.tsx
+++ b/src/components/ui/shadcnblocks-com-feature108.tsx
@@ -59,7 +59,7 @@ const Feature108 = ({
             </TabsList>
           </div>
 
-          <div className="mx-auto mt-8 max-w-screen-xl rounded-2xl bg-muted/70 p-6 lg:p-16">
+          <div className="mx-auto mt-8 max-w-4xl rounded-2xl bg-muted/70 p-6 lg:p-16">
             {tabs.map((tab) => (
               <TabsContent
                 key={tab.value}


### PR DESCRIPTION
## Summary
- Adjusts the max width of the program section container in the Feature108 component
- Changes container from `max-w-screen-xl` to `max-w-4xl` for better size control and layout consistency

## Changes

### UI Components
- **Feature108 Component**: Modified the container div wrapping the tabs content to use `max-w-4xl` instead of `max-w-screen-xl` to fix the section size

## Test plan
- [x] Verify the program section container width is constrained to `max-w-4xl`
- [x] Check layout consistency across different screen sizes
- [x] Ensure no visual regressions in the Feature108 component UI

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/dbbff6c2-398d-4932-a998-35daa6ae9417