### PR TITLE
Remove CTA buttons from Feature108 programme cards

### DIFF
--- a/src/components/ui/feature108-demo.tsx
+++ b/src/components/ui/feature108-demo.tsx
@@ -16,7 +16,6 @@ const demoData = {
         title: "De ton idée à une intention claire & actionnable",
         description:
           "Apporte ton ordi. On clarifie ton idée avec l'IA, sans jargon, puis on cadre avec la méthode Kindlin : problème → solution, business model, pricing. Tu sais où tu vas.",
-        buttonText: "Démarrer la session",
         imageSrc: "https://shadcnblocks.com/images/block/placeholder-dark-1.svg",
         imageAlt: "intention",
       },
@@ -30,7 +29,6 @@ const demoData = {
         title: "Travaille avec l'IA, étends, itère et débugge",
         description:
           "Tu apprends à dialoguer et à prompt-er efficacement. On ajoute une base simple, une API ou une extension. On voit sécurité & analytics pour des outputs qualitatifs en gardant la main sur ton projet.",
-        buttonText: "Voir la stack",
         imageSrc: "https://shadcnblocks.com/images/block/placeholder-dark-2.svg",
         imageAlt: "build",
       },
@@ -44,7 +42,6 @@ const demoData = {
         title: "Mise en ligne immédiate & rôle de Creative Product Builder",
         description:
           "On shippe : AI Code Assistant → GitHub → Netlify/Vercel → exécution async. En 2h tu repars avec une URL publique. Tu poursuis en autonomie. Tu pilotes design, code, SEO, versioning — posture « Agency of One ». Ressources & prochaines étapes incluses.",
-        buttonText: "Réserver ta place",
         imageSrc: "https://shadcnblocks.com/images/block/placeholder-dark-3.svg",
         imageAlt: "ship",
       },

--- a/src/components/ui/shadcnblocks-com-feature108.tsx
+++ b/src/components/ui/shadcnblocks-com-feature108.tsx
@@ -3,13 +3,11 @@
 import { Layout, Pointer, Zap } from "lucide-react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 
 interface TabContent {
   badge: string
   title: string
   description: string
-  buttonText: string
   imageSrc: string
   imageAlt: string
 }
@@ -70,9 +68,6 @@ const Feature108 = ({
                   <Badge variant="outline" className="w-fit bg-background">{tab.content.badge}</Badge>
                   <h3 className="text-3xl font-semibold lg:text-5xl">{tab.content.title}</h3>
                   <p className="text-muted-foreground lg:text-lg">{tab.content.description}</p>
-                  <Button className="mt-2.5 w-fit gap-2" size="lg">
-                    {tab.content.buttonText}
-                  </Button>
                 </div>
                 <img src={tab.content.imageSrc} alt={tab.content.imageAlt} className="rounded-xl" />
               </TabsContent>


### PR DESCRIPTION
## Summary
- Removed call-to-action (CTA) buttons from the Feature108 programme cards in the UI components
- Updated `feature108-demo.tsx` and `shadcnblocks-com-feature108.tsx` to no longer render button elements

## Changes

### UI Components
- **feature108-demo.tsx**: Deleted `buttonText` properties from the demo data objects
- **shadcnblocks-com-feature108.tsx**: Removed import and usage of the `Button` component that displayed the CTA buttons

## Test plan
- [x] Verify that the programme cards render without any CTA buttons
- [x] Confirm no visual regressions or layout issues after button removal
- [x] Check that the rest of the content (titles, descriptions, images) remains unchanged and displays correctly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/27a6d765-0197-4746-bebe-924f99ecb787