### PR TITLE
Adjust scroll margin for pricing section on landing page

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -17,7 +17,7 @@ export default function Pricing() {
   const t = useTranslation();
 
   return (
-    <section id="pricing" className="py-12 md:py-20 lg:py-32 bg-muted/30 scroll-mt-16">
+    <section id="pricing" className="py-12 md:py-20 lg:py-32 bg-muted/30 scroll-mt-8">
       <div className="container mx-auto px-4">
 
         <div className="text-center max-w-3xl mx-auto mb-8 md:mb-16">


### PR DESCRIPTION
## Summary
- Modified the scroll margin top value for the pricing section on the landing page

## Changes

### UI Adjustment
- Changed `scroll-mt-16` to `scroll-mt-8` in the pricing section to reduce the scroll offset when navigating to this section

## Test plan
- [ ] Verify that scrolling to the pricing section positions it correctly with the updated margin
- [ ] Check that the layout and spacing remain visually consistent across different screen sizes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ca48ee49-3e6a-4d32-b907-994c612ab25a