### PR TITLE
Adjust scroll margin top in Pricing section for better layout

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -17,7 +17,7 @@ export default function Pricing() {
   const t = useTranslation();
 
   return (
-    <section id="pricing" className="py-12 md:py-20 lg:py-32 bg-muted/30 scroll-mt-8">
+    <section id="pricing" className="py-12 md:py-20 lg:py-32 bg-muted/30 scroll-mt-4">
       <div className="container mx-auto px-4">
 
         <div className="text-center max-w-3xl mx-auto mb-8 md:mb-16">


### PR DESCRIPTION
## Summary
- Modified the scroll margin top value in the Pricing section of the landing page
- Changed from `scroll-mt-8` to `scroll-mt-4` to improve spacing and layout when scrolling

## Changes

### UI Component Updates
- **Pricing Component**: Updated the `section` element's className to reduce the scroll margin top from 8 to 4

## Test plan
- [x] Verify the Pricing section scrolls with the updated margin
- [x] Check the visual spacing on different screen sizes (mobile, tablet, desktop)
- [x] Ensure no layout regressions occur in the landing page pricing area

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ca48ee49-3e6a-4d32-b907-994c612ab25a