### PR TITLE
Fix scroll margin top in pricing section

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -17,7 +17,7 @@ export default function Pricing() {
   const t = useTranslation();
 
   return (
-    <section id="pricing" className="py-12 md:py-20 lg:py-32 bg-muted/30 scroll-mt-4">
+    <section id="pricing" className="py-12 md:py-20 lg:py-32 bg-muted/30 -scroll-mt-8">
       <div className="container mx-auto px-4">
 
         <div className="text-center max-w-3xl mx-auto mb-8 md:mb-16">


### PR DESCRIPTION
## Summary
- Adjusts the scroll margin top value in the pricing section for better layout consistency

## Changes

### UI Components
- Modified the `pricing.tsx` component:
  - Changed `scroll-mt-4` to `-scroll-mt-8` on the pricing section element

## Test plan
- [x] Verify the pricing section scroll behavior is as expected
- [x] Check that the layout and spacing around the pricing section remain visually consistent

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ca48ee49-3e6a-4d32-b907-994c612ab25a