### PR TITLE
Unify pricing cards titles for consistency

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -533,7 +533,7 @@ export const translations: Record<Language, Translations> = {
       description: "Chaque formule vous transmet la même compétence :<br />apprendre à coder de bout en bout par la pratique et devenir Product Builder.",
       plans: {
         starter: {
-          title: "⭐ Starter",
+          title: "🚀 Product Builder Masterclass",
           price: "149 €",
           description: "TTC / -26 ans & demandeurs d'emploi",
           features: [
@@ -545,7 +545,7 @@ export const translations: Record<Language, Translations> = {
           buttonText: "Je m'inscris — 149 €"
         },
         standard: {
-          title: "🚀 Devenez Product Builder",
+          title: "🚀 Product Builder Masterclass",
           price: "299 €",
           description: "TTC / personne",
           features: [
@@ -952,7 +952,7 @@ export const translations: Record<Language, Translations> = {
       description: "Each formula gives you the same skill:<br />learn to code end-to-end through practice and become a Product Builder.",
       plans: {
         starter: {
-          title: "⭐ Starter",
+          title: "🚀 Product Builder Masterclass",
           price: "€149",
           description: "Tax incl. / Under 26 & job seekers",
           features: [
@@ -964,7 +964,7 @@ export const translations: Record<Language, Translations> = {
           buttonText: "Register — €149"
         },
         standard: {
-          title: "🚀 Become a Product Builder",
+          title: "🚀 Product Builder Masterclass",
           price: "€299",
           description: "Tax incl. / person",
           features: [


### PR DESCRIPTION
## 🎯 Summary
Unifie les titres des cartes pricing pour refléter que les formules Starter et Standard proposent la même Masterclass avec des tarifs différents.

## 🔄 Changes
- **Before:** "⭐ Starter" vs "🚀 Devenez Product Builder" / "🚀 Become a Product Builder"
- **After:** "🚀 Product Builder Masterclass" pour les deux cartes (FR & EN)
- Différenciation maintenue uniquement via les descriptions tarifaires

## 💡 Rationale
- Élimine la hiérarchie implicite trompeuse entre les deux formules
- Clarifie que c'est le même contenu avec des conditions tarifaires adaptées selon la situation (-26 ans vs standard)
- Évite la survente avec "Devenez" qui peut créer de fausses attentes
- Améliore la cohérence de l'expérience utilisateur
- Message unifié : même initiation au Vibe Coding pour devenir Product Builder, tarifs adaptés

## ✅ Test Plan
- [ ] Vérifier l'affichage des cartes pricing en français et anglais
- [ ] Contrôler que les liens d'inscription Stripe fonctionnent toujours
- [ ] S'assurer que la différenciation tarifaire reste claire dans les descriptions
- [ ] Vérifier la cohérence visuelle des deux cartes avec le même titre

## 📱 Impact
Cette modification améliore la transparence de l'offre en clarifiant que les deux formules donnent accès à la même Masterclass, avec une différenciation tarifaire basée uniquement sur les critères d'éligibilité (âge et statut d'emploi).