### PR TITLE
Unify pricing card titles by standardizing font size

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -35,7 +35,7 @@ export default function Pricing() {
           {/* Starter Card - Featured */}
           <Card className="flex flex-col h-full w-full max-w-sm border-2 border-accent shadow-2xl shadow-accent/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
             <CardHeader className="pb-4">
-              <CardTitle className="font-headline text-2xl">
+              <CardTitle className="font-headline text-xl">
                 {t.pricing.plans.starter.title}
               </CardTitle>
               <div className="flex items-baseline gap-2">
@@ -99,7 +99,7 @@ export default function Pricing() {
           {/* Team Card */}
           <Card className="flex flex-col h-full w-full max-w-sm transition-all hover:scale-[1.02] hover:shadow-lg">
             <CardHeader className="pb-4">
-              <CardTitle className="font-headline text-2xl">
+              <CardTitle className="font-headline text-xl">
                 {t.pricing.plans.team.title}
               </CardTitle>
               <div className="flex items-baseline gap-2">


### PR DESCRIPTION
## Summary
- Standardizes the font size of pricing card titles across the Starter and Team plans
- Changes the font size from 2xl to xl for a more unified and consistent appearance

## Changes

### UI Components
- **Pricing Component**: Updated the `CardTitle` elements for Starter and Team pricing cards to use `text-xl` instead of `text-2xl`

## Test plan
- [ ] Verify that the Starter and Team pricing card titles display with the same font size
- [ ] Check that the visual hierarchy remains clear and consistent across pricing cards
- [ ] Ensure no layout or styling regressions occur on different screen sizes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6bda0959-df22-40ed-8383-60da029e8a6e