### PR TITLE
Unify Team Pricing Card Styles with Green Border and Shadow

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -97,7 +97,7 @@ export default function Pricing() {
           </Card>
 
           {/* Team Card */}
-          <Card className="flex flex-col h-full w-full max-w-sm transition-all hover:scale-[1.02] hover:shadow-lg">
+          <Card className="flex flex-col h-full w-full max-w-sm border-2 border-green-500 shadow-2xl shadow-green-500/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
             <CardHeader className="pb-4">
               <CardTitle className="font-headline text-xl">
                 {t.pricing.plans.team.title}
@@ -115,7 +115,7 @@ export default function Pricing() {
               <ul className="space-y-3 text-sm">
                 {t.pricing.plans.team.features.map((feature) => (
                   <li key={feature} className="flex items-center gap-2">
-                    <Check className="h-4 w-4 text-primary" />
+                    <Check className="h-4 w-4 text-green-500" />
                     <span className="text-muted-foreground">{feature}</span>
                   </li>
                 ))}


### PR DESCRIPTION
## Summary
- Updated the Team pricing card to have a consistent green border and shadow styling
- Changed the check icon color to green to match the new card theme

## Changes

### UI Components
- **Team Card**: Added `border-2 border-green-500` and `shadow-2xl shadow-green-500/20` classes for a unified green-themed border and shadow
- **Check Icon**: Updated color from `text-primary` to `text-green-500` for visual consistency with the card

## Test plan
- [x] Verify the Team pricing card displays with the new green border and shadow
- [x] Confirm the check icons in the Team card features list are green
- [x] Ensure hover scale and shadow effects remain functional and smooth

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6bda0959-df22-40ed-8383-60da029e8a6e