### PR TITLE
Unify Pricing Card Footer Styles, Update Button Texts, and Rename Team Plan to Company

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -96,7 +96,7 @@ export default function Pricing() {
             </CardFooter>
           </Card>
 
-          {/* Team Card */}
+          {/* Company Card */}
           <Card className="flex flex-col h-full w-full max-w-sm border-2 border-green-500 shadow-2xl shadow-green-500/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
             <CardHeader className="pb-4">
               <CardTitle className="font-headline text-xl">

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -87,12 +87,12 @@ export default function Pricing() {
                 ))}
               </ul>
             </CardContent>
-            <CardFooter>
+            <CardFooter className="flex-col gap-3">
               <Button className="w-full" asChild>
                 <Link href="https://buy.stripe.com/bJe5kEdSrgkcfhQaBn7EQ0c">
                   {t.pricing.plans.standard.buttonText}
                 </Link>
-              </Button>{" "}
+              </Button>
             </CardFooter>
           </Card>
 
@@ -121,12 +121,12 @@ export default function Pricing() {
                 ))}
               </ul>
             </CardContent>
-            <CardFooter>
-              <Button className="w-full" variant="outline" asChild>
+            <CardFooter className="flex-col gap-3">
+              <Button className="w-full border-2 border-green-500 text-green-500 hover:bg-green-500 hover:text-white transition-colors" asChild>
                 <Link href="https://cal.com/tewfiqferahi/15min">
                   {t.pricing.plans.team.buttonText}
                 </Link>
-              </Button>{" "}
+              </Button>
             </CardFooter>
           </Card>
         </div>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -558,7 +558,7 @@ export const translations: Record<Language, Translations> = {
           buttonText: "Réserver — 299 €"
         },
         team: {
-          title: "👥 Équipe",
+          title: "🏢 Entreprise",
           price: "Sur devis",
           description: "Entreprise / École (5 à 20 pers.)",
           features: [
@@ -977,7 +977,7 @@ export const translations: Record<Language, Translations> = {
           buttonText: "Book — €299"
         },
         team: {
-          title: "👥 Team",
+          title: "🏢 Company",
           price: "Custom quote",
           description: "Company / School (5 to 20 people)",
           features: [

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -567,7 +567,7 @@ export const translations: Record<Language, Translations> = {
             "Planning dédié",
             "Idéal pour écoles, agences et incubateurs"
           ],
-          buttonText: "Demander un devis"
+          buttonText: "Réserver une Session"
         }
       }
     },
@@ -986,7 +986,7 @@ export const translations: Record<Language, Translations> = {
             "Dedicated scheduling",
             "Ideal for schools, agencies and incubators"
           ],
-          buttonText: "Request quote"
+          buttonText: "Book a Session"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Standardizes the layout of pricing card footers by adding consistent flex column and gap styles
- Updates button styles for the company plan to have a green border and hover effect
- Changes button text for the "Dedicated scheduling" plan from "Request quote" to "Book a Session" in both English and French translations
- Renames the "Team" plan to "Company" in both English and French translations

## Changes

### UI Components
- Added `flex-col gap-3` classes to `CardFooter` components in pricing cards for consistent vertical spacing
- Updated the company plan button to have a green border, green text, and hover background color transition

### Translations
- Modified plan title and button text for the dedicated scheduling plan:
  - French: plan title from "👥 Équipe" to "🏢 Entreprise", button text from "Demander un devis" to "Réserver une Session"
  - English: plan title from "👥 Team" to "🏢 Company", button text from "Request quote" to "Book a Session"

## Test plan
- [x] Verify pricing card footers have consistent spacing and layout
- [x] Confirm company plan button displays with updated green border and hover styles
- [x] Check that the plan title and button text for the dedicated scheduling plan is updated correctly in both English and French
- [x] Test links on buttons to ensure they navigate correctly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6bda0959-df22-40ed-8383-60da029e8a6e
