### PR TITLE
Fix CTA Entreprise Colors in Pricing Component

### DIFF
--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -97,7 +97,7 @@ export default function Pricing() {
           </Card>
 
           {/* Company Card */}
-          <Card className="flex flex-col h-full w-full max-w-sm border-2 border-green-500 shadow-2xl shadow-green-500/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
+          <Card className="flex flex-col h-full w-full max-w-sm border-2 border-slate-300 shadow-2xl shadow-slate-300/20 relative transition-all hover:scale-[1.02] hover:shadow-2xl">
             <CardHeader className="pb-4">
               <CardTitle className="font-headline text-xl">
                 {t.pricing.plans.team.title}
@@ -115,14 +115,14 @@ export default function Pricing() {
               <ul className="space-y-3 text-sm">
                 {t.pricing.plans.team.features.map((feature) => (
                   <li key={feature} className="flex items-center gap-2">
-                    <Check className="h-4 w-4 text-green-500" />
+                    <Check className="h-4 w-4 text-slate-600" />
                     <span className="text-muted-foreground">{feature}</span>
                   </li>
                 ))}
               </ul>
             </CardContent>
             <CardFooter className="flex-col gap-3">
-              <Button className="w-full border-2 border-green-500 text-white hover:bg-green-500 hover:text-white transition-colors" asChild>
+              <Button className="w-full bg-slate-700 hover:bg-slate-800 text-white border-2 border-slate-700 hover:border-slate-800 transition-colors" asChild>
                 <Link href="https://cal.com/tewfiqferahi/15min">
                   {t.pricing.plans.team.buttonText}
                 </Link>


### PR DESCRIPTION
## Summary
- Updated the color scheme for the Company Card in the pricing component
- Changed border, shadow, check icon, and button colors from green to slate tones
- Improved visual consistency and hover effects for the Company Card

## Changes

### UI Components
- **Company Card**: 
  - Border color changed from green-500 to slate-300
  - Shadow color changed from green-500/20 to slate-300/20
  - Check icon color changed from green-500 to slate-600
  - Button styles updated to use slate-700 background and border with hover effects

## Test plan
- [x] Verify Company Card border and shadow colors reflect slate tones
- [x] Confirm check icons use slate-600 color
- [x] Ensure button background and border colors update correctly on hover
- [x] Check overall visual consistency and responsiveness of the Company Card on the pricing page

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bc1ba84d-1f18-4a7c-b5e5-88283baffd1d