### PR TITLE
Adjust drop-shadow styling on Hero component headline

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -19,7 +19,7 @@ export default function Hero() {
           <SocialProofBadge />
         </div>
         
-        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-headline drop-shadow-[3px_3px_0px_rgba(0,0,0,1)] dark:drop-shadow-[3px_3px_0px_rgba(255,255,255,0.4)]">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-headline drop-shadow-[2px_2px_0px_rgba(0,0,0,0.15)] dark:drop-shadow-[2px_2px_0px_rgba(255,255,255,0.2)]">
           {/* Version mobile */}
           <span className="block md:hidden">
             {t.hero.title.mobile.line1}<br />


### PR DESCRIPTION
## Summary
- Modified the drop-shadow style on the main headline in the Hero component for a more subtle visual effect

## Changes

### UI Styling
- Updated `src/components/landing/hero.tsx`:
  - Reduced drop-shadow offset from `3px 3px` to `2px 2px`
  - Adjusted shadow color opacity for both light and dark modes:
    - Light mode shadow color changed from `rgba(0,0,0,1)` to `rgba(0,0,0,0.15)`
    - Dark mode shadow color changed from `rgba(255,255,255,0.4)` to `rgba(255,255,255,0.2)`

This change enhances the visual presentation of the headline by softening the shadow effect, improving readability and aesthetic balance.

## Test plan
- Verified that the headline text still renders correctly across viewport sizes
- Checked both light and dark mode appearances to confirm shadow updates
- Ensured no layout or responsiveness regressions occurred

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/de578990-97cd-4dda-8c23-b90ada705973