### PR TITLE
Add line breaks in translation titles and adjust hero heading shadow color for improved formatting

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -19,7 +19,7 @@ export default function Hero() {
           <SocialProofBadge />
         </div>
         
-        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-headline drop-shadow-[2px_2px_0px_rgba(0,0,0,0.15)] dark:drop-shadow-[2px_2px_0px_rgba(255,255,255,0.2)]">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-headline drop-shadow-[2px_2px_0px_rgba(192,38,211,0.6)] dark:drop-shadow-[2px_2px_0px_rgba(192,38,211,0.75)]">
           {/* Version mobile */}
           <span className="block md:hidden">
             {t.hero.title.mobile.line1}<br />

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -481,7 +481,7 @@ export const translations: Record<Language, Translations> = {
         ship: {
           label: "3 • Ship",
           badge: "Phase 3 — Ship & Grow",
-          title: "Mise en ligne immédiate & rôle de Creative Product Builder",
+          title: "Mise en ligne immédiate<br />& rôle de Creative Product Builder",
           description: "On shippe : AI Code Assistant → GitHub → Netlify/Vercel → exécution async. En 2h tu repars avec une URL publique. Tu poursuis en autonomie. Tu pilotes design, code, SEO, versioning — posture « Agency of One ». Ressources & prochaines étapes incluses."
         }
       }
@@ -906,7 +906,7 @@ export const translations: Record<Language, Translations> = {
         intention: {
           label: "1 • Intention",
           badge: "Phase 1 — Intention",
-          title: "From your idea to a clear & actionable intention",
+          title: "From your idea to<br />a clear & actionable intention",
           description: "Bring your laptop. We clarify your idea with AI, without jargon, then frame it with the Kindlin method: problem → solution, business model, pricing. You know where you're going."
         },
         build: {
@@ -918,7 +918,7 @@ export const translations: Record<Language, Translations> = {
         ship: {
           label: "3 • Ship",
           badge: "Phase 3 — Ship & Grow",
-          title: "Immediate online deployment & Creative Product Builder role",
+          title: "Immediate online deployment<br />& Creative Product Builder role",
           description: "We ship: AI Code Assistant → GitHub → Netlify/Vercel → async execution. In 2h you leave with a public URL. You continue autonomously. You manage design, code, SEO, versioning — 'Agency of One' approach. Resources & next steps included."
         }
       }


### PR DESCRIPTION
## Summary
- Inserted HTML `<br />` tags in select translation titles to enhance readability
- Updated French and English translation strings in `src/lib/translations.ts`
- Modified the drop shadow color of the main heading in `src/components/landing/hero.tsx` from default black/white to purple shades for better visual emphasis

## Changes

### Translation Updates
- Modified phase 3 "Ship" title in French:
  - From: `Mise en ligne immédiate & rôle de Creative Product Builder`
  - To: `Mise en ligne immédiate<br />& rôle de Creative Product Builder`
- Modified phase 1 "Intention" title in English:
  - From: `From your idea to a clear & actionable intention`
  - To: `From your idea to<br />a clear & actionable intention`
- Modified phase 3 "Ship" title in English:
  - From: `Immediate online deployment & Creative Product Builder role`
  - To: `Immediate online deployment<br />& Creative Product Builder role`

### UI Styling Update
- Updated the drop shadow color on the hero heading in `src/components/landing/hero.tsx`:
  - From black/white shades
  - To purple shades (`rgba(192,38,211,0.6)` and `rgba(192,38,211,0.75)` for light and dark modes respectively)

These changes improve both the readability of translation titles and the visual styling of the landing page hero.

## Test plan
- [x] Verified that titles display with line breaks correctly in the UI
- [x] Confirmed no translation text is truncated or malformed
- [x] Reviewed UI rendering in both French and English locales
- [x] Confirmed updated drop shadow color appears correctly on the hero heading in light and dark modes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/de578990-97cd-4dda-8c23-b90ada705973