### PR TITLE
Render feature titles as HTML in Feature108 component

### DIFF
--- a/src/components/ui/shadcnblocks-com-feature108.tsx
+++ b/src/components/ui/shadcnblocks-com-feature108.tsx
@@ -66,7 +66,7 @@ const Feature108 = ({
               >
                 <div className="flex flex-col gap-5">
                   <Badge variant="outline" className="w-fit bg-background dark:bg-background/50">{tab.content.badge}</Badge>
-                  <h3 className="text-3xl font-semibold lg:text-5xl">{tab.content.title}</h3>
+                  <h3 className="text-3xl font-semibold lg:text-5xl" dangerouslySetInnerHTML={{ __html: tab.content.title }}></h3>
                   <p className="text-muted-foreground lg:text-lg">{tab.content.description}</p>
                 </div>
                 <img src={tab.content.imageSrc} alt={tab.content.imageAlt} className="rounded-xl" />


### PR DESCRIPTION
## Summary
- Enable rendering of rich HTML content in titles within the `Feature108` component
- Replace plain text title rendering with `dangerouslySetInnerHTML` to support HTML formatting

## Changes

### UI Components
- Updated `src/components/ui/shadcnblocks-com-feature108.tsx`:
  - Changed `<h3>` element rendering `tab.content.title` from plain text to HTML using `dangerouslySetInnerHTML`

## Test plan
- [x] Verify that titles containing HTML tags render correctly within the `Feature108` component
- [x] Confirm no layout or styling regressions occur due to HTML rendering
- [x] Ensure no console warnings or errors related to the change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/de578990-97cd-4dda-8c23-b90ada705973