### PR TITLE
fix(translations): add line break in 1ère Masterclass title

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -865,7 +865,7 @@ export const translations: Record<Language, Translations> = {
       }
     },
     firstMasterclassGallery: {
-      title: "1ère Masterclass — Samedi 4 Octobre 2025",
+      title: "1ère Masterclass\nSamedi 4 Octobre 2025",
       thanksMessage: "Un grand merci aux participants studieux, participatifs et prolifiques ! 🎉",
       participatingCompanies: "Avec la participation de"
     }


### PR DESCRIPTION
## Summary
- Updated the title of the `firstMasterclassGallery` translation to include a line break
- Improves readability by splitting the event name and date onto separate lines

## Changes

### Translations
- Modified `src/lib/translations.ts`:
  - Replaced the original title string:
    ```
    "1ère Masterclass — Samedi 4 Octobre 2025"
    ```
  - With a version containing a newline character:
    ```
    "1ère Masterclass\nSamedi 4 Octobre 2025"
    ```

## Test plan
- Verified the displayed title in the UI reflects the line break
- Confirmed no regressions in other translation keys
- Ensured proper rendering across supported languages (if applicable)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/282f47d7-e796-4598-927f-d1f306b41628