### PR TITLE
Add clickable partner image links with external URLs

### DIFF
--- a/src/components/landing/first-masterclass-gallery.tsx
+++ b/src/components/landing/first-masterclass-gallery.tsx
@@ -68,18 +68,22 @@ const companies = [
   {
     name: "Seven Boys & Girls",
     logo: "/companies/seven.png",
+    url: "https://sevenboysandgirls.com/",
   },
   {
     name: "Le Progrès",
     logo: "/companies/le-progres.png",
+    url: "https://www.leprogresmarais.fr/",
   },
   {
     name: "Moon Croissant",
     logo: "/companies/moon.png",
+    url: "https://www.mooncoffeeshopworld.com/",
   },
   {
     name: "Ray Ban Meta",
     logo: "/companies/rayban-meta.png",
+    url: "https://www.instagram.com/raybanmeta/",
   },
 ];
 
@@ -181,9 +185,12 @@ export default function FirstMasterclassGallery() {
           </p>
           <div className="flex flex-wrap items-center justify-center gap-8 md:gap-12">
             {companies.map((company, index) => (
-              <div
+              <a
                 key={index}
-                className="relative w-20 h-20 md:w-24 md:h-24 flex items-center justify-center grayscale hover:grayscale-0 transition-all duration-300 opacity-70 hover:opacity-100"
+                href={company.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative w-20 h-20 md:w-24 md:h-24 flex items-center justify-center grayscale hover:grayscale-0 transition-all duration-300 opacity-70 hover:opacity-100 cursor-pointer"
               >
                 <Image
                   src={company.logo}
@@ -192,7 +199,7 @@ export default function FirstMasterclassGallery() {
                   height={100}
                   className="object-contain"
                 />
-              </div>
+              </a>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Enhanced the FirstMasterclassGallery component to make partner logos clickable
- Added associated external URLs for each partner to enable navigation
- Wrapped logo images with anchor tags that open links in new tabs with proper security attributes

## Changes

### UI Updates
- Replaced non-clickable `div` wrappers around company logos with `<a>` elements
- Added `href`, `target="_blank"`, and `rel="noopener noreferrer"` attributes for safe external linking
- Updated cursor style to pointer for better UX when hovering logos

### Data Updates
- Added `url` property to each partner company object in the `companies` array:
  - Seven Boys & Girls: https://sevenboysandgirls.com/
  - Le Progrès: https://www.leprogresmarais.fr/
  - Moon Croissant: https://www.mooncoffeeshopworld.com/
  - Ray Ban Meta: https://www.instagram.com/raybanmeta/

## Test plan
- [x] Verified each partner logo is now a clickable link
- [x] Confirmed links open in a new browser tab
- [x] Checked anchor tag attributes for proper security (`noopener noreferrer`)
- [x] Ensured hover and cursor styles behave as expected
- [x] Manual visual inspection of gallery layout intact

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8ad7e8c7-1229-4ada-a1d2-b5e11c209ed7