### PR TITLE
Fix line break in '2ème Batch — Prochaine Masterclass' title

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -855,7 +855,7 @@ export const translations: Record<Language, Translations> = {
       description: "Un atelier intensif et accessible. Tu explores, tu structures, tu repars avec un projet en ligne. Une compétence exploitable, en seulement 2h."
     },
     nextMasterclass: {
-      title: "2ème Batch — Prochaine Masterclass",
+      title: "2ème Batch\nProchaine Masterclass",
       subtitle: "Rejoins-nous pour la prochaine session à Paris",
       info: {
         date: "Samedi 18 octobre 2025",


### PR DESCRIPTION
## Summary
- Corrects the title formatting for the "2ème Batch — Prochaine Masterclass" section by adding an explicit newline character

## Changes

### Translation Updates
- Modified the `nextMasterclass.title` string in French translations to include a line break between "2ème Batch" and "Prochaine Masterclass"
- This change improves title readability and layout in the UI

## Test plan
- [x] Verify the title displays on two lines in the UI for the French locale
- [x] Confirm no regression or layout issues occur due to the newline addition

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/279a1b45-c900-46f6-abdd-6430348efee9