### PR TITLE
Swap order of WorkshopsSection and FirstMasterclassGallery on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,13 +19,13 @@ export default function Home() {
         <Hero />
         <Programme />
 
-        <WorkshopsSection />
+        <FirstMasterclassGallery />
         <WhyCards />
         <section id="comment-ca-marche">
           <MethodSteps />
         </section>
         <Pricing />
-        <FirstMasterclassGallery />
+        <WorkshopsSection />
         <Faq />
         <Changelog />
       </main>


### PR DESCRIPTION
## Summary
- Reordered components on the home page to swap `WorkshopsSection` and `FirstMasterclassGallery`
- Placed `FirstMasterclassGallery` before `WhyCards` instead of `WorkshopsSection`
- Moved `WorkshopsSection` below `Pricing` after `FirstMasterclassGallery`

## Changes

### UI Component Order
- Changed the rendering order in `src/app/page.tsx`:
  - Replaced the first `<WorkshopsSection />` with `<FirstMasterclassGallery />` above the `WhyCards` section
  - Moved `<WorkshopsSection />` to be rendered after `<Pricing />` and before `<Faq />`

This swap likely improves content flow or aligns with updated design requirements.

## Test plan
- [x] Verify the home page renders both components without errors
- [x] Confirm the visual order reflects the intended swap
- [x] Check for any layout regressions caused by the component reordering

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/df951a87-f141-439b-9995-5860cade3569